### PR TITLE
Add vendor rebate column to the summary report

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,15 +83,20 @@
   padding: 1rem;
   border-radius: 4px;
   margin-bottom: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
 .report-header p {
   margin-bottom: 0.5rem;
+  flex: 1 1 40%;
 }
 
 .report-table {
   width: 100%;
   border-collapse: collapse;
+  overflow-x: auto;
 }
 
 .report-table th,
@@ -109,6 +114,17 @@
 .report-table tfoot {
   font-weight: bold;
   background-color: #f5f5f5;
+}
+
+/* Rebate Column Styles */
+.report-table th:nth-child(4), /* Rebate % column */
+.report-table td:nth-child(4) {
+  background-color: #e8f4ff;
+}
+
+.report-table th:nth-child(5), /* Rebate Value column */
+.report-table td:nth-child(5) {
+  background-color: #e0f0ff; 
 }
 
 /* Status Badge Styles */
@@ -145,6 +161,14 @@
 }
 
 /* Responsive Adjustments */
+@media (max-width: 992px) {
+  .report-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}
+
 @media (max-width: 768px) {
   .app-header h1 {
     font-size: 1.5rem;
@@ -156,5 +180,14 @@
   
   .summary-report h3 {
     font-size: 1.4rem;
+  }
+  
+  .report-header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  
+  .report-header p {
+    flex: 0 0 100%;
   }
 }

--- a/src/components/SummaryReport.js
+++ b/src/components/SummaryReport.js
@@ -4,6 +4,12 @@ function SummaryReport({ vendor, selectedContracts }) {
   // Calculate total contract value
   const totalValue = selectedContracts.reduce((sum, contract) => sum + contract.value, 0);
   
+  // Calculate total rebate value
+  const totalRebateValue = selectedContracts.reduce(
+    (sum, contract) => sum + (contract.value * contract.rebate / 100), 
+    0
+  );
+  
   // Check if any contracts are selected
   if (!vendor || selectedContracts.length === 0) {
     return (
@@ -21,6 +27,7 @@ function SummaryReport({ vendor, selectedContracts }) {
         <p><strong>Vendor:</strong> {vendor.name}</p>
         <p><strong>Selected Contracts:</strong> {selectedContracts.length}</p>
         <p><strong>Total Value:</strong> ${totalValue.toLocaleString()}</p>
+        <p><strong>Total Rebate:</strong> ${totalRebateValue.toLocaleString()}</p>
       </div>
       
       <table className="table table-striped report-table">
@@ -29,31 +36,43 @@ function SummaryReport({ vendor, selectedContracts }) {
             <th>Contract ID</th>
             <th>Contract Name</th>
             <th>Value</th>
+            <th>Rebate (%)</th>
+            <th>Rebate Value</th>
             <th>Start Date</th>
             <th>End Date</th>
             <th>Status</th>
           </tr>
         </thead>
         <tbody>
-          {selectedContracts.map(contract => (
-            <tr key={contract.id}>
-              <td>{contract.id}</td>
-              <td>{contract.name}</td>
-              <td>${contract.value.toLocaleString()}</td>
-              <td>{contract.startDate}</td>
-              <td>{contract.endDate}</td>
-              <td>
-                <span className={`status-badge ${contract.status.toLowerCase()}`}>
-                  {contract.status}
-                </span>
-              </td>
-            </tr>
-          ))}
+          {selectedContracts.map(contract => {
+            // Calculate rebate value for this contract
+            const rebateValue = contract.value * contract.rebate / 100;
+            
+            return (
+              <tr key={contract.id}>
+                <td>{contract.id}</td>
+                <td>{contract.name}</td>
+                <td>${contract.value.toLocaleString()}</td>
+                <td>{contract.rebate}%</td>
+                <td>${rebateValue.toLocaleString()}</td>
+                <td>{contract.startDate}</td>
+                <td>{contract.endDate}</td>
+                <td>
+                  <span className={`status-badge ${contract.status.toLowerCase()}`}>
+                    {contract.status}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
         <tfoot>
           <tr>
             <td colSpan="2"><strong>Total</strong></td>
-            <td colSpan="4"><strong>${totalValue.toLocaleString()}</strong></td>
+            <td><strong>${totalValue.toLocaleString()}</strong></td>
+            <td></td>
+            <td><strong>${totalRebateValue.toLocaleString()}</strong></td>
+            <td colSpan="3"></td>
           </tr>
         </tfoot>
       </table>

--- a/src/data/vendorData.js
+++ b/src/data/vendorData.js
@@ -4,43 +4,43 @@ const vendorData = [
     id: 1,
     name: "Acme Corporation",
     contracts: [
-      { id: 101, name: "Office Supplies", value: 25000, startDate: "2025-01-15", endDate: "2026-01-14", status: "Active" },
-      { id: 102, name: "IT Support", value: 75000, startDate: "2024-11-01", endDate: "2025-10-31", status: "Active" },
-      { id: 103, name: "Equipment Maintenance", value: 45000, startDate: "2024-08-15", endDate: "2025-08-14", status: "Active" }
+      { id: 101, name: "Office Supplies", value: 25000, rebate: 2.5, startDate: "2025-01-15", endDate: "2026-01-14", status: "Active" },
+      { id: 102, name: "IT Support", value: 75000, rebate: 3.0, startDate: "2024-11-01", endDate: "2025-10-31", status: "Active" },
+      { id: 103, name: "Equipment Maintenance", value: 45000, rebate: 1.5, startDate: "2024-08-15", endDate: "2025-08-14", status: "Active" }
     ]
   },
   {
     id: 2,
     name: "TechSolutions Inc.",
     contracts: [
-      { id: 201, name: "Software Development", value: 120000, startDate: "2024-12-01", endDate: "2025-12-01", status: "Active" },
-      { id: 202, name: "Cloud Services", value: 85000, startDate: "2025-01-01", endDate: "2025-12-31", status: "Active" },
-      { id: 203, name: "Data Analytics", value: 65000, startDate: "2024-10-15", endDate: "2025-04-14", status: "Active" }
+      { id: 201, name: "Software Development", value: 120000, rebate: 4.0, startDate: "2024-12-01", endDate: "2025-12-01", status: "Active" },
+      { id: 202, name: "Cloud Services", value: 85000, rebate: 3.5, startDate: "2025-01-01", endDate: "2025-12-31", status: "Active" },
+      { id: 203, name: "Data Analytics", value: 65000, rebate: 2.0, startDate: "2024-10-15", endDate: "2025-04-14", status: "Active" }
     ]
   },
   {
     id: 3,
     name: "Global Logistics",
     contracts: [
-      { id: 301, name: "Transportation Services", value: 95000, startDate: "2025-02-01", endDate: "2026-01-31", status: "Active" },
-      { id: 302, name: "Warehouse Management", value: 110000, startDate: "2024-09-15", endDate: "2025-09-14", status: "Active" }
+      { id: 301, name: "Transportation Services", value: 95000, rebate: 2.0, startDate: "2025-02-01", endDate: "2026-01-31", status: "Active" },
+      { id: 302, name: "Warehouse Management", value: 110000, rebate: 1.0, startDate: "2024-09-15", endDate: "2025-09-14", status: "Active" }
     ]
   },
   {
     id: 4,
     name: "Creative Design Co.",
     contracts: [
-      { id: 401, name: "Website Redesign", value: 35000, startDate: "2025-01-15", endDate: "2025-04-14", status: "Active" },
-      { id: 402, name: "Marketing Materials", value: 28000, startDate: "2024-11-01", endDate: "2025-02-28", status: "Active" },
-      { id: 403, name: "Brand Strategy", value: 55000, startDate: "2025-03-01", endDate: "2025-08-31", status: "Pending" }
+      { id: 401, name: "Website Redesign", value: 35000, rebate: 5.0, startDate: "2025-01-15", endDate: "2025-04-14", status: "Active" },
+      { id: 402, name: "Marketing Materials", value: 28000, rebate: 3.5, startDate: "2024-11-01", endDate: "2025-02-28", status: "Active" },
+      { id: 403, name: "Brand Strategy", value: 55000, rebate: 4.5, startDate: "2025-03-01", endDate: "2025-08-31", status: "Pending" }
     ]
   },
   {
     id: 5,
     name: "Secure Systems Ltd.",
     contracts: [
-      { id: 501, name: "Security Auditing", value: 42000, startDate: "2024-12-15", endDate: "2025-03-14", status: "Active" },
-      { id: 502, name: "Surveillance Equipment", value: 78000, startDate: "2025-02-01", endDate: "2025-08-31", status: "Active" }
+      { id: 501, name: "Security Auditing", value: 42000, rebate: 2.5, startDate: "2024-12-15", endDate: "2025-03-14", status: "Active" },
+      { id: 502, name: "Surveillance Equipment", value: 78000, rebate: 3.0, startDate: "2025-02-01", endDate: "2025-08-31", status: "Active" }
     ]
   }
 ];


### PR DESCRIPTION
## Description
This pull request adds a vendor rebate column to the summary report as requested in issue #1.

## Changes Made
- Added rebate percentage field to each contract in the vendor data
- Added two new columns to the summary report table:
  - Rebate percentage (%)
  - Rebate value ($)
- Added calculation of rebate value for each contract
- Added calculation of total rebate value in the summary
- Updated CSS to style the rebate columns with a light blue background
- Enhanced the responsive design to handle the additional columns

## Screenshots
*Screenshots will be added after deployment*

## How to Test
1. Run the application
2. Select a vendor from the dropdown
3. Select one or more contracts
4. Verify the rebate percentage and rebate value columns appear in the summary report
5. Verify the rebate values are correctly calculated (contract value * rebate percentage)
6. Verify the total rebate value is correctly calculated in the summary header and footer

Closes #1
